### PR TITLE
Improve forecast loading and add tests

### DIFF
--- a/ai_crypto.py
+++ b/ai_crypto.py
@@ -7,7 +7,6 @@ from time import sleep
 from binance.client import Client
 
 from datetime import timedelta
-from binance.client import Client
 from sklearn.preprocessing import RobustScaler
 from sklearn.metrics import mean_absolute_error, mean_squared_error
 import joblib
@@ -206,6 +205,22 @@ def build_model(input_timesteps, input_dim, pred_len):
     return model
 
 def walk_forward_eval(X, Y, folds=FOLDS):
+    """Create index splits for walk-forward evaluation.
+
+    Parameters
+    ----------
+    X : np.ndarray
+        Масив ознак (використовується тільки для визначення довжини).
+    Y : np.ndarray
+        Відповідні цільові значення (довжина має збігатися з ``X``).
+    folds : int, optional
+        Кількість фолдів для розбиття, за замовчуванням ``FOLDS``.
+
+    Returns
+    -------
+    list[tuple[tuple[int, int], tuple[int, int]]]
+        Список пар ``((train_start, train_end), (test_start, test_end))``.
+    """
     n = len(X)
     fold_size = n // (folds + 1)
     splits = []
@@ -371,6 +386,6 @@ def main():
     save_forecast_csv_png(df[['timestamp','close']].assign(close=df['close']), fut_prices)
 
 if __name__ == "__main__":
-    # Запобіжник для старих Mac: вимкнути AVX помилки TensorFlow (опціонально)
+    # Приглушити надмірні інформаційні повідомлення TensorFlow
     os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
     main()

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -42,8 +42,14 @@ def load_forecast_text(max_days: int = 7) -> str:
 
     try:
         df = pd.read_csv(CSV_PATH)
-        # Шукаємо колонку з прогнозом
-        col = "forecast" if "forecast" in df.columns else df.columns[0]
+        # Вибір колонки з прогнозом: спочатку 'predicted_close_usd', потім 'forecast',
+        # і лише як запасний варіант беремо перший стовпець
+        if "predicted_close_usd" in df.columns:
+            col = "predicted_close_usd"
+        elif "forecast" in df.columns:
+            col = "forecast"
+        else:
+            col = df.columns[0]
         vals = df[col].tolist()[:max_days]
 
         lines = ["📈 Прогноз ціни BTC на 7 днів:"]

--- a/tests/test_load_forecast_text.py
+++ b/tests/test_load_forecast_text.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import telegram_bot
+
+
+def test_load_forecast_uses_predicted_column(tmp_path, monkeypatch):
+    df = pd.DataFrame({"predicted_close_usd": [100.0], "other": [1]})
+    csv_path = tmp_path / "forecast.csv"
+    df.to_csv(csv_path, index=False)
+    monkeypatch.setattr(telegram_bot, "CSV_PATH", csv_path)
+    text = telegram_bot.load_forecast_text()
+    assert "День 1: $100.00" in text
+
+
+def test_load_forecast_missing_file(tmp_path, monkeypatch):
+    csv_path = tmp_path / "missing.csv"
+    monkeypatch.setattr(telegram_bot, "CSV_PATH", csv_path)
+    text = telegram_bot.load_forecast_text()
+    assert "Файл прогнозу не знайдено" in text


### PR DESCRIPTION
## Summary
- remove duplicate Client import
- refine forecast column selection in bot
- document walk_forward evaluation helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893944c7a6c8327a02947034cb328a2